### PR TITLE
fix install-deps-only option

### DIFF
--- a/spark-submit-flamegraph
+++ b/spark-submit-flamegraph
@@ -238,7 +238,7 @@ main() {
   flamegraph_title="Spark Application"
 
   if [ -z "${ONLY_INSTALL_DEPS+proceed}" ]; then
-    echo "Proceeding..."
+    : echo "Proceeding..."
   else
     install_deps
     exit 0

--- a/spark-submit-flamegraph
+++ b/spark-submit-flamegraph
@@ -237,7 +237,9 @@ main() {
   influx_uri=http://${local_ip}:${influx_http_port}
   flamegraph_title="Spark Application"
 
-  if [ -n "${ONLY_INSTALL_DEPS}" ]; then
+  if [ -z "${ONLY_INSTALL_DEPS+proceed}" ]; then
+    echo "Proceeding..."
+  else
     install_deps
     exit 0
   fi

--- a/spark-submit-flamegraph
+++ b/spark-submit-flamegraph
@@ -237,9 +237,7 @@ main() {
   influx_uri=http://${local_ip}:${influx_http_port}
   flamegraph_title="Spark Application"
 
-  if [ -z "${ONLY_INSTALL_DEPS+proceed}" ]; then
-    : echo "Proceeding..."
-  else
+  if [ ! -z "${ONLY_INSTALL_DEPS}" ]; then
     install_deps
     exit 0
   fi


### PR DESCRIPTION
On AWS emr-5.21.0

   $ ONLY_INSTALL_DEPS="yes" spark-submit-flamegraph

works as expected, but

   $ spark-submit-flamegraph ...

complains:

   /usr/local/bin/spark-submit-flamegraph: line 240: ONLY_INSTALL_DEPS: unbound variable

This commit should fix that.